### PR TITLE
Update fxn.py to use a print function

### DIFF
--- a/mrpython/fxn.py
+++ b/mrpython/fxn.py
@@ -51,12 +51,12 @@ def walk(
         _graph_path=[], _graph_current=0, _debug=False):
 
     if _debug:
-        print '-----------'
-        print 'V: %s' % (value)
-        print 'GM: %s' % (graph_max)
-        print 'GP: %s' % (_graph_path)
-        print 'GC: %s' % (_graph_current)
-        print '-----------'
+        print('-----------')
+        print('V: %s' % (value))
+        print('GM: %s' % (graph_max))
+        print('GP: %s' % (_graph_path))
+        print('GC: %s' % (_graph_current))
+        print('-----------')
         raw_input('s >')
 
     def _recur(v):


### PR DESCRIPTION
This stops a syntax error when using Python 3. This doesn't make it Python 3 compatible but it will at least let the module be imported (and installed) on Py3
